### PR TITLE
掲示板フォームのパーシャル化

### DIFF
--- a/app/assets/stylesheets/board.scss
+++ b/app/assets/stylesheets/board.scss
@@ -7,3 +7,35 @@
 	margin-top: 30px;
 }
 
+
+.actions {
+	margin-top: 20px;
+}
+
+.board-show {
+	margin: 30px auto;
+	border: 3px solid black;
+	padding: 25px;
+	border-radius: 10px;
+}
+
+
+.board-body {
+	padding: 5px;
+	border: 2px solid gray; /*質問内容*/
+}
+
+.board-profile {
+	margin-top: 15px; /*質問の投稿者*/
+}
+
+
+.answer-header {
+	margin-top: 20px; /*cssが効いてない*/
+}
+.answer-form {
+  border-bottom: 4px solid gray;
+  padding-bottom: 5px;
+
+}
+

--- a/app/controllers/public/board_comments_controller.rb
+++ b/app/controllers/public/board_comments_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Public::BoardCommentsController < ApplicationController
-
   before_action :authenticate_user!
 
   def index; end

--- a/app/controllers/public/board_comments_controller.rb
+++ b/app/controllers/public/board_comments_controller.rb
@@ -4,7 +4,7 @@ class Public::BoardCommentsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-
+  	binding.pry
   end
 
   def destroy; end

--- a/app/controllers/public/board_comments_controller.rb
+++ b/app/controllers/public/board_comments_controller.rb
@@ -3,7 +3,15 @@
 class Public::BoardCommentsController < ApplicationController
   before_action :authenticate_user!
 
-  def index; end
+  def create
+
+  end
+
+  def destroy; end
+
+  def edit; end
+
+
 
   def edit; end
 end

--- a/app/controllers/public/boards_controller.rb
+++ b/app/controllers/public/boards_controller.rb
@@ -34,7 +34,7 @@ class Public::BoardsController < ApplicationController
   def update
     if @board.update(board_params)
       redirect_to public_board_path(@board)
-      flash[:notice] = "successful"
+      flash[:notice] = "successful!"
     else
       render :edit
     end

--- a/app/controllers/public/boards_controller.rb
+++ b/app/controllers/public/boards_controller.rb
@@ -25,7 +25,8 @@ class Public::BoardsController < ApplicationController
 
   def show; end
 
-  def edit; end
+  def edit
+  end
 
   def update
     if @board.update(board_params)

--- a/app/controllers/public/boards_controller.rb
+++ b/app/controllers/public/boards_controller.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class Public::BoardsController < ApplicationController
-
   before_action :authenticate_user!
-  before_action :set_board, only: %i[show edit update ]
+  before_action :set_board, only: %i[show edit update]
 
   def new
     @board = Board.new
@@ -24,11 +23,9 @@ class Public::BoardsController < ApplicationController
     @boards = Board.page(params[:page]).per(10)
   end
 
-  def show
-  end
+  def show; end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @board.update(board_params)
@@ -38,7 +35,6 @@ class Public::BoardsController < ApplicationController
       render :edit
     end
   end
-
 
   private
 

--- a/app/controllers/public/boards_controller.rb
+++ b/app/controllers/public/boards_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Public::BoardsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_board, only: %i[show edit update]
@@ -24,7 +22,8 @@ class Public::BoardsController < ApplicationController
   end
 
   def show
-    @board_comment = @board.board_comments.new
+    #@board_comment = @board.board_comments.new
+    @board_comment = BoardComment.new
     #binding.pry
   end
 
@@ -48,5 +47,8 @@ class Public::BoardsController < ApplicationController
 
   def set_board
     @board = Board.find(params[:id])
+    #@name = controller.action_name
+    @name = action_name
   end
+
 end

--- a/app/controllers/public/boards_controller.rb
+++ b/app/controllers/public/boards_controller.rb
@@ -23,7 +23,10 @@ class Public::BoardsController < ApplicationController
     @boards = Board.page(params[:page]).per(10)
   end
 
-  def show; end
+  def show
+    @board_comment = @board.board_comments.new
+    #binding.pry
+  end
 
   def edit
   end

--- a/app/controllers/public/todolists_controller.rb
+++ b/app/controllers/public/todolists_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Public::TodolistsController < ApplicationController
-
   before_action :authenticate_user!
 
   def complete; end

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -5,35 +5,31 @@ class Public::UsersController < ApplicationController
   before_action :set_user, only: %i[show edit update]
 
   def index
-  	@user = current_user.id
+    @user = current_user.id
   end
 
-  def show
-  end
+  def show; end
 
-  def edit
-  end
+  def edit; end
 
   def update
-  	if @user.update(user_params)
-  		redirect_to public_user_path(@user)
-  		flash[:notice] = "success!"
-  	else
-  		render :edit
-  	end
+    if @user.update(user_params)
+      redirect_to public_user_path(@user)
+      flash[:notice] = "success!"
+    else
+      render :edit
+    end
   end
-
-
 
   def complete; end
 
   private
 
   def user_params
-  	params.require(:user).permit(:name, :email, :profile_image)
+    params.require(:user).permit(:name, :email, :profile_image)
   end
 
   def set_user
-  	@user = User.find(params[:id])
+    @user = User.find(params[:id])
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -10,7 +10,23 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def facebook
-    callback
+    callback_from :facebook
+  end
+
+  private
+
+  def callback_from(provider)
+    provider = provider.to_s
+
+    @user = User.find_for_oauth(request.env['omniauth.auth'])
+
+    if @user.persisted?
+      flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: provider.capitalize)
+      sign_in_and_redirect @user, event: :authentication
+    else
+      session["devise.#{provider}_data"] = request.env['omniauth.auth']
+      redirect_to new_user_registration_url
+    end
   end
   # More info at:
   # https://github.com/heartcombo/devise#omniauth
@@ -31,22 +47,5 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # def after_omniauth_failure_path_for(scope)
   #   super(scope)
   # end
-  private
 
-  # Facebook／Twitter連携では処理を共通化
-  # callbackメソッドに共通化した処理を定義して呼び出す
-  # 1行目 OAuth認証の情報から取得されるユーザーが登録済みであればfind結果を、
-  # 未登録であれば新規作成したユーザーのインスタンスを返すメソッド
-  # request.env['omniauth.auth']とすることで、OAuth認証後にユーザー情報が得られる
-
-  def callback
-    @user = User.find_or_create_for_oauth(request.env['omniauth.auth'])
-
-    if @user.persisted?
-      sign_in_and_redirect @user
-    else
-      session['devise.user_attributes'] = @user.attributes
-      redirect_to new_user_registration_url
-    end
-end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -7,8 +7,5 @@ class Board < ApplicationRecord
   validates :title, presence: true, length: { maximum: 20 }
   validates :subject, presence: true, length: { maximum: 20 }
   validates :body, presence: true, length: { maximum: 2000 }
-  validates :display, inclusion: {in: [true, false]}
-
-
+  validates :display, inclusion: { in: [true, false] }
 end
-

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -4,7 +4,7 @@ class Board < ApplicationRecord
 
   attachment :image
 
-  validates :title, presence: true, length: { minimum: 2, maximum: 20 }
+  validates :title, presence: true, length: { maximum: 20 }
   validates :subject, presence: true, length: { maximum: 20 }
   validates :body, presence: true, length: { maximum: 2000 }
   validates :display, inclusion: {in: [true, false]}

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1,6 +1,7 @@
 class Board < ApplicationRecord
   belongs_to :user
-  has_many :board_tag, dependent: :destroy
+  has_many :board_tags, dependent: :destroy
+  has_many :board_comments, dependent: :destroy
 
   attachment :image
 

--- a/app/models/board_comment.rb
+++ b/app/models/board_comment.rb
@@ -1,0 +1,7 @@
+class BoardComment < ApplicationRecord
+	belongs_to :user
+	belongs_to :board
+
+	validates :comment, presence: true, length: {maximum: 2000}
+
+end

--- a/app/models/board_tag.rb
+++ b/app/models/board_tag.rb
@@ -1,4 +1,4 @@
 class BoardTag < ApplicationRecord
-	belongs_to :tag
-	belongs_to :board
+  belongs_to :tag
+  belongs_to :board
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,9 +1,6 @@
 class Tag < ApplicationRecord
-	has_many :board_tag, dependent: :destroy
+  has_many :board_tag, dependent: :destroy
 
-	validates :name, presence: true
-	validates :is_void, inclusion: {in: [true, false]}
-
+  validates :name, presence: true
+  validates :is_void, inclusion: { in: [true, false] }
 end
-
-

--- a/app/models/todolist.rb
+++ b/app/models/todolist.rb
@@ -1,5 +1,5 @@
 class Todolist < ApplicationRecord
-	belongs_to :user
+  belongs_to :user
 
-	enum time_category: { today: 0, week: 1, month: 2}
+  enum time_category: { today: 0, week: 1, month: 2 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,37 +8,34 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[twitter facebook] # 追加
   # 　deviseでOmniAuthの機能を使うことができるようになる
 
-
   has_many :boards, dependent: :destroy
   has_many :todolists, dependent: :destroy
   attachment :profile_image
 
   validates :name, presence: true
 
-
-
   # find_or_create_for_oauthメソッド => コールバック用コントローラーで呼び出す
   # new_with_sessionメソッド => ユーザー登録用コントローラーから呼び出す
 
-  #class << self
-    def find_or_create_for_oauth(auth)
-      find_or_create_by!(email: auth.info.email) do |user|
-        user.provider = auth.provider
-        user.uid = auth.uid
-        user.name = auth.info.name
-        user.email = auth.info.email
-        password = Devise.friendly_token[0..5]
-        logger.debug password
-        user.password = password
-      end
+  # class << self
+  def find_or_create_for_oauth(auth)
+    find_or_create_by!(email: auth.info.email) do |user|
+      user.provider = auth.provider
+      user.uid = auth.uid
+      user.name = auth.info.name
+      user.email = auth.info.email
+      password = Devise.friendly_token[0..5]
+      logger.debug password
+      user.password = password
     end
+  end
 
-    def new_with_session(params, session)
-      if user_attributes = session['devise.user_attributes']
-        new(user_attributes) { |user| user.attributes = params }
-      else
-        super
-      end
+  def new_with_session(params, session)
+    if user_attributes = session['devise.user_attributes']
+      new(user_attributes) { |user| user.attributes = params }
+    else
+      super
     end
-  #end
+  end
+  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,14 +6,16 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[twitter facebook] # 追加
-  # 　deviseでOmniAuthの機能を使うことができるようになる
 
   has_many :boards, dependent: :destroy
   has_many :todolists, dependent: :destroy
+  has_many :boards, dependent: :destroy
+
   attachment :profile_image
 
   validates :name, presence: true
 
+  # deviseでOmniAuthの機能を使うことができるようになる
   # find_or_create_for_oauthメソッド => コールバック用コントローラーで呼び出す
   # new_with_sessionメソッド => ユーザー登録用コントローラーから呼び出す
 

--- a/app/views/public/boards/_form.html.erb
+++ b/app/views/public/boards/_form.html.erb
@@ -1,36 +1,19 @@
-<%= form_with(model: board, url: public_boards_path, local: true) do |f| %>
-<%#= form_for board do |f| %>
+<!--form_withのURL指定のエラー回避のため、POST用とPATCH用とで条件分岐する-->
+<!--controller_name : コントローラとアクションの情報を取り出すメソッド, コントローラを確認-->
 
-<!--url:  public_boards_path-->
+<% if controller_name == "edit" %>
+<%# if @name == "edit" %>
+	<%= form_with(model: board, url: public_board_path, local: true) do |f| %>
+	  <%= render 'shared/error_messages', obj: board %>
+	  <%= render 'form_group', f:f %>
 
-	<!--partial: 'shared/error_messages'だとエラーになる-->
-	<!--入子のパーシャル-->
-	<%= render 'shared/error_messages', obj: @board %>
-
-	<div class="form-group">
-		<%= f.label :タイトル %>
-		<%= f.text_field :title, class: 'form-control' %>
-	</div>
-
-	<div class="form-group">
-		<%= f.label :件名 %>
-		<%= f.text_field :subject, class: 'form-control' %>
-	</div>
-
-	<div class="form-group">
-		<%= f.label :本文 %>
-		<%= f.text_area :body, class: 'form-control' %>
-	</div>
-
-	<div class="form-group">
-		<%= f.attachment_field :image, placeholder: 'プロフィール画像', class: 'board-image-form' %>
-	</div>
-
-
-	<div class="actions">
-		<%= f.submit '投稿する', class: 'form-control' %>
-	</div>
-
-
-
+	<% end %>
+<% else %>
+    <%# binding.pry %>
+	<%= form_with(model: board, url: public_boards_path, local: true) do |f| %>
+	  <%= render 'shared/error_messages', obj: board %>
+	  <%= render 'form_group', f:f %>
+	<% end %>
 <% end %>
+
+

--- a/app/views/public/boards/_form.html.erb
+++ b/app/views/public/boards/_form.html.erb
@@ -1,22 +1,4 @@
-<div class="row">
-	<div class="col-xs-12">
-
-	<!--プレビュー機能があると良い-->
-
-
-	<h2>編集フォーム</h2>
-
-	<!--投稿フォームうまくいかない-->
-	<%= render 'form', board: @board %>
-	</div>
-
-</div>
-
-
-
-<h1>test</h1>
-
-<%= form_with(model: @board, url: public_board_path, local: true) do |f| %>
+<%= form_with(model: board, url: public_boards_path, local: true) do |f| %>
 <%#= form_for board do |f| %>
 
 <!--url:  public_boards_path-->

--- a/app/views/public/boards/_form_group.html.erb
+++ b/app/views/public/boards/_form_group.html.erb
@@ -1,0 +1,26 @@
+
+<!--パーシャル内パーシャル-->
+<div class="form-group">
+	<%= f.label :タイトル %>
+	<%= f.text_field :title, class: 'form-control' %>
+</div>
+
+<div class="form-group">
+	<%= f.label :件名 %>
+	<%= f.text_field :subject, class: 'form-control' %>
+</div>
+
+<div class="form-group">
+	<%= f.label :本文 %>
+	<%= f.text_area :body, class: 'form-control' %>
+</div>
+
+<div class="form-group">
+	<%= f.attachment_field :image, placeholder: 'プロフィール画像', class: 'board-image-form' %>
+</div>
+
+
+<div class="actions">
+	<%= f.submit '投稿する', class: 'form-control' %>
+</div>
+

--- a/app/views/public/boards/edit.html.erb
+++ b/app/views/public/boards/edit.html.erb
@@ -7,7 +7,7 @@
 	<h2>編集フォーム</h2>
 
 	<!--投稿フォームうまくいかない-->
-	<%= render 'form', board: @board %>
+	<%= render 'form', board: @board, obj: @board, controller_name: @name %>
 	</div>
 
 </div>

--- a/app/views/public/boards/index.html.erb
+++ b/app/views/public/boards/index.html.erb
@@ -10,24 +10,27 @@
 
 
 <table class="table table-hover">
-	<thead>
-		<th>画像</th>
+	<thead class="thead-light">
 		<th>ユーザー名</th>
 		<th>タイトル</th>
+		<th >件名</th>
 		<th>投稿日時</th>
 		<th>詳細</th>
 	</thead>
 	<tbody>
 		<% @boards.each do |board| %>
 		<tr>
-
-			<td><%= attachment_image_tag(board.user, :profile_image, :fill, 200, 200, fallback: 'no_image.jpg', size: '60x60') %></td>
-			<!--ユーザーページへのリンク-->
-			<td><%= link_to board.user.name, '#' %></td>
+			<td><!--ユーザーページへのリンクに後ほど変更-->
+				<%= link_to public_board_path(board) do %>
+					<%= attachment_image_tag(board.user, :profile_image, :fill, 200, 200, fallback: 'no_image.jpg', size: '30x30') %><br />
+					<p><%= board.user.name %></p>
+				<% end %>
+			</td>
 			<td><%= board.title %></td>
+			<td><%= board.subject %></td>
 			<td><%= l board.created_at %></td>
-			<td><%= link_to '詳細', public_board_path(board), class: 'btn btn-outline-info' %></td>
 
+			<td><%= link_to '詳細', public_board_path(board), class: 'btn btn-outline-info' %></td>
 		</tr>
 		<% end %>
 	</tbody>

--- a/app/views/public/boards/new.html.erb
+++ b/app/views/public/boards/new.html.erb
@@ -5,38 +5,9 @@
 
 
 	<h2>新規投稿</h2>
-		<%= form_with(model: @board, url:  public_boards_path, local: true) do |f| %>
 
-			<!--partial: 'shared/error_messages'だとエラーになる-->
-			<%= render 'shared/error_messages', obj: @board %>
-
-			<div class="field">
-				<%= f.label :タイトル %>
-				<%= f.text_field :title, class: 'form-control' %>
-			</div>
-
-			<div class="field">
-				<%= f.label :件名 %>
-				<%= f.text_field :subject, class: 'form-control' %>
-			</div>
-
-			<div class="field">
-				<%= f.label :本文 %>
-				<%= f.text_area :body, class: 'form-control' %>
-			</div>
-
-			<div class="field">
-				<%= f.attachment_field :image, placeholder: 'プロフィール画像', class: 'board-image-form' %>
-			</div>
-
-
-			<div class="action">
-				<%= f.submit '投稿する', class: 'form-control' %>
-			</div>
-
-
-
-		<% end %>
+	<!--投稿フォーム-->
+	<%= render 'form', board: @board %>
 	</div>
 
 </div>

--- a/app/views/public/boards/new.html.erb
+++ b/app/views/public/boards/new.html.erb
@@ -7,9 +7,8 @@
 	<h2>新規投稿</h2>
 		<%= form_with(model: @board, url:  public_boards_path, local: true) do |f| %>
 
-		<!--エラーメッセ-->
-		<%= render partial: 'shared/error_messages', locals: { obj: @board} %>
-
+			<!--partial: 'shared/error_messages'だとエラーになる-->
+			<%= render 'shared/error_messages', obj: @board %>
 
 			<div class="field">
 				<%= f.label :タイトル %>

--- a/app/views/public/boards/show.html.erb
+++ b/app/views/public/boards/show.html.erb
@@ -1,22 +1,63 @@
-<div class="d-flex align-items-center mt-4 mb-4">
-  <!--mxは中央-->
+<!--mr-1 :0.25rem /mr/mt/mb/ml-->
+<div class="d-flex align-items-center mt-3 mb-2">
+  <div class="mr-auto p-1">
+    <h2>掲示板詳細</h2>
+  </div>
   <div class="ml-auto">
     <%= link_to '一覧', public_boards_path, class: 'btn btn-outline-dark' %>
     <%= link_to '編集', edit_public_board_path(@board), class: 'btn btn-outline-dark' %>
   </div>
 </div>
 
-<div class="board-show">
-  <div class="board-header">
-    <h4><%= @board.title %></h4>
+
+
+  <div class="board-show">
+    <div class="board-header">
+      <h4><%= @board.title %></h4>
+    </div>
+    <div class="board-body">
+      <p class="board-text"><%= simple_format(@board.body) %></p>
+    </div>
+    <div class="board-profile">
+          <p class="text-right font-weight-bold mr-10">
+            <%= link_to public_user_path(@board.user) do %>
+              <%= @board.user.name %>
+              <%= attachment_image_tag @board.user.profile_image, :profile_image, :fill, 200, 200, fallback: 'no_image.jpg', size: '40x40' %>
+            <% end %>
+         </p>
+      </div>
   </div>
-  <div class="board-body">
-    <p class="board-text"><%= simple_format(@board.body) %></p>
-    <p class="text-right font-weight-bold mr-10">
-    	<%= link_to public_user_path(@board.user) do %>
-	    	<%= @board.user.name %>
-	    	<%= attachment_image_tag @board.user.profile_image, :profile_image, :fill, 200, 200, fallback: 'no_image.jpg', size: '40x40' %>
-    	<% end %>
-    </p>
-  </div>
+
+
+<!--回答一覧-->
+
+<div class="comments">
+  <h4>回答一覧</h4>
 </div>
+
+<!--パーシャルで設定 回答フォーム-->
+<div class="answer-form">
+  <div class="answer-header">
+    <h4>質問に回答する</h4>
+  </div>
+
+   <div class="answer-body">
+      <%= form_with(model: @board_comment, url: public_board_comments_path, local: true) do |f| %>
+
+         <%#= f.hidden_field :board_id %>
+        <div class="form-group">
+          <%= f.text_area :board_comment, class: 'form-control', rows: 6 %>
+        </div>
+
+
+        <div class="actions">
+          <%= f.submit '送信する', class: 'btn btn-outline-info' %>
+        </div>
+
+      <% end %>
+    </div>
+</div>
+
+
+
+

--- a/app/views/public/boards/show.html.erb
+++ b/app/views/public/boards/show.html.erb
@@ -1,7 +1,8 @@
 <div class="d-flex align-items-center mt-4 mb-4">
-  <div class="ml-auto boards__linkBox">
-<!--     <%#= link_to '一覧', boards_path, class: 'btn btn-outline-dark' %>
-    <%#= link_to '編集', edit_board_path(@board), class: 'btn btn-outline-dark' %> -->
+  <!--mxは中央-->
+  <div class="ml-auto">
+    <%= link_to '一覧', public_boards_path, class: 'btn btn-outline-dark' %>
+    <%= link_to '編集', edit_public_board_path(@board), class: 'btn btn-outline-dark' %>
   </div>
 </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module StudyRecord
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja # タイムゾーンの設定
 
+    #正規表現を使い、config/locales以下のディレクトリ内にある全てのymlファイルを読み込む
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module StudyRecord
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja # タイムゾーンの設定
 
-    #正規表現を使い、config/locales以下のディレクトリ内にある全てのymlファイルを読み込む
+    # 正規表現を使い、config/locales以下のディレクトリ内にある全てのymlファイルを読み込む
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :facebook, ENV['295670171812798'], ENV['5d5f652a6f4585d4e493e5ecb19d86da']
+  config.omniauth :facebook, FACEBOOK_ID='295670171812798', FACEBOOK_SECRET_KEY='5d5f652a6f4585d4e493e5ecb19d86da'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    models:
+      board: 掲示板
+    attributes:
+      board:
+        title: タイトル
+        subject: 件名
+        body: 本文

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -39,9 +39,9 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 plugin :tmp_restart
 
 # ポート9292でSSL接続する
-if ENV.fetch('RAILS_ENV') { 'development' } == 'development'
-  ssl_bind '0.0.0.0', '9292', {
-    key: 'tmp/server.key',
-    cert: 'tmp/server.crt'
-  }
-end
+# if ENV.fetch('RAILS_ENV') { 'development' } == 'development'
+#   ssl_bind '0.0.0.0', '9292', {
+#     key: 'tmp/server.key',
+#     cert: 'tmp/server.crt'
+#   }
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     resources :boards, only: %i[new create index edit show update]
 
     #patch '/public/boards/:id' => 'boards#update'
+    resources :board_comments, only: %i[create destroy]
     resources :users, only: %i[index show edit update]
 
     get 'todolists/complete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
   get 'home/about'
 
   namespace :public do
-    resources :boards, only: %i[new create index show edit]
+    resources :boards, only: %i[new create index edit show update]
+
+    #patch '/public/boards/:id' => 'boards#update'
     resources :users, only: %i[index show edit update]
 
     get 'todolists/complete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-
   devise_for :users, controllers: {
     sessions: 'users/sessions',
     passwords: 'users/passwords',

--- a/db/migrate/20200624070555_create_board_comments.rb
+++ b/db/migrate/20200624070555_create_board_comments.rb
@@ -1,0 +1,11 @@
+class CreateBoardComments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :board_comments do |t|
+      t.integer :user_id
+      t.integer :board_id
+      t.string :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_003505) do
+ActiveRecord::Schema.define(version: 2020_06_24_070555) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 2020_06_24_003505) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "board_comments", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "board_id"
+    t.string "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "board_tags", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,9 +27,8 @@ Admin.create!(
   )
 end
 
-
 # 50boards
-50.times do |n|
+50.times do |_n|
   user_id = rand(1..50)
   title = Faker::Games::Pokemon.name
   subject = "質問したいことがあります。その{n}"

--- a/test/fixtures/board_comments.yml
+++ b/test/fixtures/board_comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  board_id: 1
+  comment: MyString
+
+two:
+  user_id: 1
+  board_id: 1
+  comment: MyString

--- a/test/models/board_comment_test.rb
+++ b/test/models/board_comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BoardCommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#実装概要

* バリデーションメッセージの日本語化
-model/ja.ymlファイルを新規作成。対応する日本語を記述。

* 掲示板フォームのパーシャル化
-action_nameメソッドを使用。
-渡ってきた値がeditかcreateアクションかによって、条件分岐させる。
-エラーに対処した結果、パーシャルの中にパーシャルを作成することになった

* facebookの認証機能、修正
- デプロイ時はまた別途、作業が必要
- pumaのサーバ設定は、結果不要だったため、削除した


